### PR TITLE
Improve input parsing

### DIFF
--- a/server/src/controller/actions-controller.ts
+++ b/server/src/controller/actions-controller.ts
@@ -3,23 +3,7 @@ import { NodeVM } from "vm2";
 import Problem from "../models/Problem";
 import { IProblem, IResult } from "../types/types";
 import Submission from "../models/Submission";
-
-function parseInput(inputStr: string): any {
-  const obj: any = {};
-
-  const regex = /(\w+)\s*=\s*(\[[^\]]*\]|[^,]+)/g;
-  let match;
-  while ((match = regex.exec(inputStr)) !== null) {
-    const key = match[1];
-    const valueStr = match[2].trim();
-    try {
-      obj[key] = eval(valueStr);
-    } catch (err) {
-      obj[key] = valueStr;
-    }
-  }
-  return obj;
-}
+import { parseInput, parseValue } from "../utils/parsing";
 
 export const executeCode: RequestHandler = async (req, res, next) => {
   try {
@@ -76,7 +60,7 @@ export const executeCode: RequestHandler = async (req, res, next) => {
 
       try {
         const inputObj = parseInput(example.input);
-        const expectedOutput = eval(example.output);
+        const expectedOutput = parseValue(example.output);
         const userOutput = userModule.solve(inputObj);
         const passed =
           JSON.stringify(userOutput) === JSON.stringify(expectedOutput);

--- a/server/src/utils/parsing.ts
+++ b/server/src/utils/parsing.ts
@@ -1,0 +1,26 @@
+export function parseValue(valueStr: string): any {
+  const trimmed = valueStr.trim();
+  if (trimmed === '') return trimmed;
+  if (/^-?\d+(?:\.\d+)?$/.test(trimmed)) {
+    return Number(trimmed);
+  }
+  if (trimmed === 'true') return true;
+  if (trimmed === 'false') return false;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return trimmed.replace(/^['"]?(.*?)['"]?$/, '$1');
+  }
+}
+
+export function parseInput(inputStr: string): Record<string, any> {
+  const obj: Record<string, any> = {};
+  const regex = /(\w+)\s*=\s*(\[[^\]]*\]|[^,]+)/g;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(inputStr)) !== null) {
+    const key = match[1];
+    const valueStr = match[2];
+    obj[key] = parseValue(valueStr);
+  }
+  return obj;
+}


### PR DESCRIPTION
## Summary
- avoid `eval` when parsing input or output
- add a parsing utility to safely parse example values

## Testing
- `npm test` in `server` (fails: no test specified)
- `npm test` in `client` (fails: missing script)

------
https://chatgpt.com/codex/tasks/task_e_683f74ec9f9c832591b88c0bb6c74cef